### PR TITLE
Always wrap in transaction

### DIFF
--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -100,8 +100,10 @@ module ClosureTree
 
     def with_advisory_lock(&block)
       if options[:with_advisory_lock]
-        model_class.with_advisory_lock(advisory_lock_name) do
-          transaction { yield }
+        transaction do
+          model_class.with_advisory_lock(advisory_lock_name) do
+            yield
+          end
         end
       else
         yield


### PR DESCRIPTION
- This is to stop pgbouncer from freeing up the connection after the transaction
is done and never calling `pg_advisory_unlock`

cc @mikeastock @jfrost @mcasper 