### PR TITLE
Update to rebuild! class method

### DIFF
--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -110,8 +110,10 @@ module ClosureTree
       # Note that the hierarchy table will be truncated.
       def rebuild!
         _ct.with_advisory_lock do
-          hierarchy_class.delete_all # not destroy_all -- we just want a simple truncate.
-          roots.each { |n| n.send(:rebuild!) } # roots just uses the parent_id column, so this is safe.
+          roots.each do |n|
+            n.delete_hierarchy_references # delete hierarchies scoped to the caller
+            n.send(:rebuild!) # roots just uses the parent_id column, so this is safe.
+          end
         end
         nil
       end

--- a/spec/hierarchy_maintenance_spec.rb
+++ b/spec/hierarchy_maintenance_spec.rb
@@ -8,8 +8,10 @@ describe ClosureTree::HierarchyMaintenance do
       end
       hierarchy_count = MetalHierarchy.count
       expect(hierarchy_count).to be > (20*2)-1 # shallowest-possible case, where all children use the first root
-      MetalHierarchy.delete_all
-      Metal.rebuild!
+      Metal.roots.each do |n|
+        n.delete_hierarchy_references # delete hierarchies scoped to the caller
+        n.send(:rebuild!) # roots just uses the parent_id column, so this is safe.
+      end
       expect(MetalHierarchy.count).to eq(hierarchy_count)
     end
   end


### PR DESCRIPTION
I just recently found out that `project.locations.rebuild!` was deleting the entire location_hierarchies table, but only rebuilding the hierarchies for that collection. 

The change made was to only delete the hierarchies that you are trying to rebuild.